### PR TITLE
:sparkles: add compiler option per os

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,40 @@ jobs:
           dotnet tool run dotnet-format pact.sln
       - name: Build pact
         run: |
-          dotnet build --no-restore pact.sln
+          dotnet build -p:DefineConstants="LINUX=1"  --no-restore pact.sln
+      - name: Test
+        run: |
+          dotnet test --no-restore --no-build pact.sln
+
+  build-osx:
+    runs-on: macos-11
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+      - name: Restore cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-6.0.x-${{ hashFiles('**/packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-6.0.x-${{ hashFiles('**/packages.lock.json') }}
+            ${{ runner.os }}-nuget-6.0.x-
+            ${{ runner.os }}-nuget-
+      - name: Install dotnet tool
+        run: |
+          dotnet tool restore
+      - name: Restore nuget package
+        run: |
+          dotnet restore --use-lock-file --locked-mode pact.sln
+      - name: Check source format
+        run: |
+          dotnet tool run dotnet-format pact.sln
+      - name: Build pact
+        run: |
+          dotnet build -p:DefineConstants="OSX=1" --no-restore pact.sln
       - name: Test
         run: |
           dotnet test --no-restore --no-build pact.sln

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           VERSION: ${{ steps.get_version.outputs.version-without-v }}
         run: |
-          dotnet publish --no-restore -c Release /p:Version="$VERSION" -r osx-x64 -o publish --sc src/Pact.Cli/Pact.Cli.csproj
+          dotnet publish --no-restore -c Release -p:Version="$VERSION" -p:DefineConstants="OSX=1" -r osx-x64 -o publish --sc src/Pact.Cli/Pact.Cli.csproj
       - name: Archive
         working-directory: publish
         env:
@@ -89,7 +89,7 @@ jobs:
           RID: ${{ matrix.os-runtime }}
           VERSION: ${{ steps.get_version.outputs.version-without-v }}
         run: |
-          dotnet publish --no-restore -c Release /p:Version="$VERSION" -r "$RID" -o publish --sc src/Pact.Cli/Pact.Cli.csproj
+          dotnet publish --no-restore -c Release -p:Version="$VERSION" -p:DefineConstants="LINUX=1"  -r "$RID" -o publish --sc src/Pact.Cli/Pact.Cli.csproj
       - name: Archive
         working-directory: publish
         env:


### PR DESCRIPTION
# Add compiler option per os

<!-- Thank you for submitting a pull request to our repo. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Add compiler option of defines construct per target os.

## Description

`podman` is need to change the command per os.

Constructs is need.
